### PR TITLE
fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,6 @@ jobs:
         run: ./scripts/build.sh
       - name: Test
         run: ./scripts/test.sh
-      - name: CDK-Synth
-        run: ./scripts/cdk-synth.sh
+      - name: CDK-Synth-No-Lookup
+        run: ./scripts/cdk-synth-no-lookup.sh
             

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ sudo pip3 install git-remote-codecommit
 ```bash
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD);
 git remote add downstream codecommit::${AWS_REGION}://${RES_ACCOUNT_AWS_PROFILE}@${GIT_REPOSITORY};
-git commit -am "init downstream";
+git commit -am "feat: init downstream";
 git push -u downstream ${CURRENT_BRANCH}:main ### default branch for CodePipeline can be configured in config/AppConfig.ts
 ```
 

--- a/scripts/cdk-synth-no-lookup.sh
+++ b/scripts/cdk-synth-no-lookup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: MIT-0
+
+set -e
+
+npm run cdk context
+npm run cdk synth -- --no-lookup


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- fix: use cdk synth --no-lookup in the Github Worklow, this helps in case you are using VPC FromLookup and dont necessarily have to connect your Github repo to the AWS Accounts to run against the vpc lookup. Instead this is done only in the CodePipeline level where you already have established the trust in the bootstrap level.
- fix: commit message for initializing downstream, wont let you commit if wrong prefix




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
