### PR TITLE
Update check-deps-python.sh

### DIFF
--- a/scripts/check-deps-python.sh
+++ b/scripts/check-deps-python.sh
@@ -50,6 +50,6 @@ fi
 for pythonModule in "${REQUIREMENTS[@]}"; do
     pythonModuleFolder=`dirname $pythonModule`;
     pushd "${pythonModuleFolder}" || exit 1;
-    pipenv requirements --exclude-markers --hash > requirements.txt && pip-audit -r requirements.txt --disable-pip && rm -rf requirements.txt;
+    pipenv requirements --exclude-markers --hash > requirements.txt && pip-audit -r requirements.txt --disable-pip && rm -rf requirements.txt || exit 1;
     popd || exit 1;
 done


### PR DESCRIPTION
pip-audit should fail if a vulnerability is found

*Issue #, if available:* N/A

*Description of changes:*

Running `npm run audit:deps:python` the script is currently not returning 1 when a vulnerability is found. Example:

```
[deps:python] Found 1 known vulnerability in 1 package
[deps:python] Name         Version ID                  Fix Versions
[deps:python] ------------ ------- ------------------- ------------
[deps:python] cryptography 41.0.4  GHSA-jfhm-5ghh-2f97 41.0.6
[deps:python] ~/work/vwp-r-ddf/vwp-r-ddf
[deps:python] npm run audit:deps:python exited with code 0
```

I am proposing to return 1. The vulnerability can be ignored by adding its Version ID with the `--ignore-vuln` option, only in case it's necessary to do so.