### PR TITLE
Pre-commit hooks should fail immediately when forgetting to export the necessary variables

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,6 +4,10 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 if [ -z $RUN_PRE_COMMIT_HOOKS ]; then exit 0; fi
+if [ -z $AWS_REGION ] || [ -z $ACCOUNT_RES ] || [ -z $RES_ACCOUNT_AWS_PROFILE ] || [ -z $CDK_QUALIFIER ] || [ -z $GIT_REPOSITORY ]; then 
+    echo "Run 'source export_vars.sh' to export the mandatory variables for building the project"
+    exit 1;
+fi
 
 ./scripts/check-audit.sh
 ./scripts/build.sh


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* when running the pre-commit hooks, if you forget to source the `export_var.sh` file, it will fail only towards the end after the tests, resulting in a big waste of time. Instead husky should fail immediately, checking the minimal required variables that are necessary for the commit to go through.

Example, without checking:

```bash
❯ time git commit -am "..."
[...omissis...]
husky - pre-commit hook exited with code 1 (error)
96.47s user 24.41s system 214% cpu 56.307 total
```

Introducing the checks before running the build and test scripts:

```bash
❯ time git commit -am "..."
Run 'source export_vars.sh' to export mandatory variables for building the project
husky - pre-commit hook exited with code 1 (error)
0.01s user 0.02s system 39% cpu 0.083 total
```

Result: almost 2 minutes saved for one commit if you forget to source the `export_var.sh` file.